### PR TITLE
fix: copied notification banner color (close #9)

### DIFF
--- a/dist/rose-pine-moon.js
+++ b/dist/rose-pine-moon.js
@@ -277,9 +277,9 @@ settings.theme = `
     top: -3rem;
     z-index: 2147483000;
     width: 80%;
-    border-radius: 0px 0px 4px 4px;
-    border: 1px solid #56526e;
-    border-top-style: none;
+    border-radius: 8px 8px 8px 8px;
+    border: 2px solid #eb6f92;
+    color: #f6c177;
     text-align: center;
     background: #232136;
     white-space: nowrap;

--- a/dist/rose-pine.js
+++ b/dist/rose-pine.js
@@ -277,9 +277,9 @@ settings.theme = `
     top: -3rem;
     z-index: 2147483000;
     width: 80%;
-    border-radius: 0px 0px 4px 4px;
-    border: 1px solid #524f67;
-    border-top-style: none;
+    border-radius: 8px 8px 8px 8px;
+    border: 2px solid #eb6f92;
+    color: #f6c177;
     text-align: center;
     background: #191724;
     white-space: nowrap;


### PR DESCRIPTION
Text color in yank popup message was black on a dark background which is refactored to appropriate colors as shown below.
![yy](https://github.com/user-attachments/assets/889cb8e2-ce57-4766-9fb8-6ee79888eb84)
